### PR TITLE
Include remote tunnel name in color identity (closes #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ hue and its source — `auto` (from workspace name), `override` (manual hue), or
 | ------------------------------------ | -------------- | -------------- | -------------------------------------------------------- |
 | `colorIdentity.enabled`             | boolean        | `true`         | Auto-apply identity colors on workspace open             |
 | `colorIdentity.colorMode`           | `"simple"` \| `"harmonized"` | `"harmonized"` | Color selection mode (see below) |
+| `colorIdentity.includeRemoteName`   | boolean        | `true`         | Include the remote/tunnel name in the identity so the same folder on different remotes gets a distinct color |
 | `colorIdentity.affectTitleBar`      | boolean        | `true`         | Colorize the title bar                                   |
 | `colorIdentity.affectActivityBar`   | boolean        | `true`         | Colorize the activity bar                                |
 | `colorIdentity.affectStatusBar`     | boolean        | `true`         | Colorize the status bar                                  |

--- a/package.json
+++ b/package.json
@@ -67,6 +67,11 @@
           ],
           "description": "Color selection mode. 'simple' uses basic theme detection; 'harmonized' generates palette options that integrate with your active theme."
         },
+        "colorIdentity.includeRemoteName": {
+          "type": "boolean",
+          "default": true,
+          "description": "When connected to a remote (tunnel, SSH, WSL, dev container), include the remote/tunnel name in the color identity so the same folder opened on different remotes gets a distinct color. Only affects automatic (name-based) hue selection."
+        },
         "colorIdentity.affectTitleBar": {
           "type": "boolean",
           "default": true,

--- a/src/colorGenerator.ts
+++ b/src/colorGenerator.ts
@@ -5,6 +5,48 @@ import { extractThemeBaseHue } from './themeAnalyzer';
 // ── Hashing ──────────────────────────────────────────────────────────────────
 
 /**
+ * Extract a stable remote name from a workspace folder authority.
+ *
+ * Remote authorities are shaped like `<kind>+<name>` — e.g. `tunnel+my-box`,
+ * `ssh-remote+devhost`, `wsl+Ubuntu`. We return the portion after the first
+ * `+` so the identity reflects the specific machine/tunnel. When there is no
+ * remote (`remoteName` is undefined) we return undefined so local windows are
+ * unaffected.
+ */
+export function extractRemoteName(
+    authority: string | undefined,
+    remoteName: string | undefined
+): string | undefined {
+    if (!remoteName) {
+        return undefined;
+    }
+    if (authority) {
+        const plus = authority.indexOf('+');
+        if (plus >= 0 && plus < authority.length - 1) {
+            return authority.slice(plus + 1);
+        }
+        return authority;
+    }
+    return remoteName;
+}
+
+/**
+ * Compose the identity string used to derive the workspace hue. When a remote
+ * name is present and enabled, it is prefixed so the same folder opened on
+ * different tunnels/hosts gets a distinct color.
+ */
+export function buildIdentityName(
+    workspaceName: string,
+    remoteName: string | undefined,
+    includeRemoteName: boolean
+): string {
+    if (includeRemoteName && remoteName) {
+        return `${remoteName}/${workspaceName}`;
+    }
+    return workspaceName;
+}
+
+/**
  * Deterministic hash of a string → number in [0, 360).
  * Uses djb2 — simple, fast, and produces a well-distributed spread.
  */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { readConfig } from './types';
-import { generateColors, hashToHue, getThemeProfile } from './colorGenerator';
+import { generateColors, hashToHue, getThemeProfile, buildIdentityName, extractRemoteName } from './colorGenerator';
 import { applyColors, resetColors } from './colorApplier';
 import { showColorPicker } from './colorPicker';
 import { clearSwatchCache } from './swatchGenerator';
@@ -20,6 +20,29 @@ function getWorkspaceName(): string | undefined {
     return undefined;
 }
 
+/** The remote/tunnel name of the current window, or undefined when local. */
+function getRemoteName(): string | undefined {
+    const folders = vscode.workspace.workspaceFolders;
+    const authority =
+        folders && folders.length > 0 ? folders[0].uri.authority : undefined;
+    return extractRemoteName(authority, vscode.env.remoteName);
+}
+
+/**
+ * The full identity string used to derive colors — the workspace name,
+ * optionally prefixed with the remote/tunnel name so the same folder opened
+ * on different tunnels/hosts gets a distinct color. Returns undefined when no
+ * workspace folder is open.
+ */
+function getIdentityName(): string | undefined {
+    const workspaceName = getWorkspaceName();
+    if (!workspaceName) {
+        return undefined;
+    }
+    const config = readConfig();
+    return buildIdentityName(workspaceName, getRemoteName(), config.includeRemoteName);
+}
+
 function getEffectiveHue(): number {
     const config = readConfig();
 
@@ -33,7 +56,7 @@ function getEffectiveHue(): number {
     if (config.hueOverride !== null) {
         return config.hueOverride;
     }
-    const name = getWorkspaceName();
+    const name = getIdentityName();
     return name ? hashToHue(name) : 0;
 }
 
@@ -64,7 +87,7 @@ async function applyIdentityColors(): Promise<void> {
     }
 
     const themeKind = vscode.window.activeColorTheme.kind;
-    const colors = generateColors(workspaceName, themeKind, config);
+    const colors = generateColors(getIdentityName()!, themeKind, config);
     await applyColors(colors);
     updateStatusBar();
 }
@@ -143,7 +166,7 @@ export function activate(context: vscode.ExtensionContext) {
                 return;
             }
             const themeKind = vscode.window.activeColorTheme.kind;
-            const colors = generateColors(workspaceName, themeKind, config);
+            const colors = generateColors(getIdentityName()!, themeKind, config);
             await applyColors(colors);
             vscode.window.showInformationMessage('ColorIdentity: Colors applied.');
         })

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,12 +1,13 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-import { hashToHue, hslToHex, getThemeProfile, generateColors } from '../../colorGenerator';
+import { hashToHue, hslToHex, getThemeProfile, generateColors, buildIdentityName, extractRemoteName } from '../../colorGenerator';
 import { ColorIdentityConfig } from '../../types';
 
 function baseConfig(overrides: Partial<ColorIdentityConfig> = {}): ColorIdentityConfig {
     return {
         enabled: true,
         colorMode: 'simple',
+        includeRemoteName: true,
         affectTitleBar: true,
         affectActivityBar: true,
         affectStatusBar: true,
@@ -71,6 +72,39 @@ suite('Color Generation', () => {
         assert.strictEqual(colors.activityBarBackground, undefined);
         assert.strictEqual(colors.statusBarBackground, undefined);
         assert.strictEqual(colors.tabsBackground, undefined);
+    });
+});
+
+suite('Remote Identity', () => {
+    test('extractRemoteName returns undefined when local', () => {
+        assert.strictEqual(extractRemoteName(undefined, undefined), undefined);
+        assert.strictEqual(extractRemoteName('tunnel+my-box', undefined), undefined);
+    });
+
+    test('extractRemoteName parses the name after the "+" separator', () => {
+        assert.strictEqual(extractRemoteName('tunnel+my-box', 'tunnel'), 'my-box');
+        assert.strictEqual(extractRemoteName('ssh-remote+devhost', 'ssh-remote'), 'devhost');
+        assert.strictEqual(extractRemoteName('wsl+Ubuntu', 'wsl'), 'Ubuntu');
+    });
+
+    test('extractRemoteName falls back to remoteName without an authority', () => {
+        assert.strictEqual(extractRemoteName(undefined, 'tunnel'), 'tunnel');
+        assert.strictEqual(extractRemoteName('codespaces', 'codespaces'), 'codespaces');
+    });
+
+    test('buildIdentityName prefixes the remote when enabled', () => {
+        assert.strictEqual(buildIdentityName('proj', 'my-box', true), 'my-box/proj');
+    });
+
+    test('buildIdentityName ignores the remote when disabled or absent', () => {
+        assert.strictEqual(buildIdentityName('proj', 'my-box', false), 'proj');
+        assert.strictEqual(buildIdentityName('proj', undefined, true), 'proj');
+    });
+
+    test('remote name changes the derived hue', () => {
+        const local = hashToHue(buildIdentityName('proj', undefined, true));
+        const remote = hashToHue(buildIdentityName('proj', 'my-box', true));
+        assert.notStrictEqual(local, remote);
     });
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type ColorMode = 'simple' | 'harmonized';
 export interface ColorIdentityConfig {
     enabled: boolean;
     colorMode: ColorMode;
+    includeRemoteName: boolean;
     affectTitleBar: boolean;
     affectActivityBar: boolean;
     affectStatusBar: boolean;
@@ -51,6 +52,7 @@ export function readConfig(): ColorIdentityConfig {
     return {
         enabled: cfg.get<boolean>('enabled', true),
         colorMode: cfg.get<ColorMode>('colorMode', 'harmonized'),
+        includeRemoteName: cfg.get<boolean>('includeRemoteName', true),
         affectTitleBar: cfg.get<boolean>('affectTitleBar', true),
         affectActivityBar: cfg.get<boolean>('affectActivityBar', true),
         affectStatusBar: cfg.get<boolean>('affectStatusBar', true),


### PR DESCRIPTION
Closes #2.

## Summary
Derives the workspace color from `<remote>/<workspace>` when the window is connected to a remote (tunnel, SSH, WSL, dev container), so the same folder opened on different tunnels/hosts gets a distinct color. Local windows are unchanged.

## Changes
- New setting **`colorIdentity.includeRemoteName`** (boolean, default `true`).
- Pure helpers `extractRemoteName` (parses `tunnel+<name>` style authorities) and `buildIdentityName` in `colorGenerator.ts`.
- `extension.ts` now composes the identity via `getIdentityName()` and uses it everywhere the hue is derived. Only automatic (name-based) hue selection is affected; `hueOverride` and harmonized modes are unchanged.
- Docs updated (README settings table + configuration property).

## Tests
Added 6 tests covering `extractRemoteName`, `buildIdentityName`, and hue divergence. Full suite: **14 passing** (lint + compile + test all green locally).
